### PR TITLE
Set level 4 as "na" (not available / not relevant)

### DIFF
--- a/check_process
+++ b/check_process
@@ -25,9 +25,7 @@
 	Level 1=auto
 	Level 2=auto
 	Level 3=auto
-# Level 4: 
-	Level 4=0
-# Level 5: 
+	Level 4=na
 	Level 5=auto
 	Level 6=auto
 	Level 7=auto


### PR DESCRIPTION
This app sounds like it could be level 7 on the CI, but sadly the level 4 is set as 0

I don't think wemawema has user accounts or even an admin interface, so LDAP/SSO integration is irrelevant and can safely be set as "na" :smile: 